### PR TITLE
Fix dgif close file

### DIFF
--- a/libbase/GnashImageGif.cpp
+++ b/libbase/GnashImageGif.cpp
@@ -118,17 +118,14 @@ GifInput::GifInput(boost::shared_ptr<IOChannel> in)
 {
 }
 
-int
+
 GifInput::~GifInput()
 {
     // Clean up allocated data.
 #if GIFLIB_MAJOR==5 && GIFLIB_MINOR==1    
-	int errorCode;
-	DGifCloseFile(_gif, &errorCode);
-	return errorCode;
+	DGifCloseFile(_gif, 0);
 #else
 	DGifCloseFile(_gif);
-	return 0;
 #endif
 }
 


### PR DESCRIPTION
So in giflib5.1 the function DGifCloseFile takes an extra argument for an error code.
I used some preprocessor to make this work when compiling against giflib5.1.
My changes will not affect anyone in any way other than making gnash work with giflib5.1

While it is not a great idea to give a nullptr to the function, in giflib 5.1 nothing bad can happen, since they check for that before using the value you passed.
